### PR TITLE
chore: onboard to Renovate for automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+    "extends": [
+        "github>biltrewards/renovate-config"
+    ]
+}


### PR DESCRIPTION
## Summary

Adds `.github/renovate.json` extending the shared company config (`github>biltrewards/renovate-config`).

**What this enables:**
- Automated dependency upgrade PRs via [Renovate](https://docs.renovatebot.com/)
- Patch and minor updates are auto-merged when CI passes
- Major updates require manual review

**Expected outcome:**
- You will start receiving PRs from Renovate for dependency updates
- CODEOWNERS will receive more GitHub notifications from these automated PRs
- No action needed beyond reviewing major upgrade PRs — patch/minor PRs merge themselves on green CI

The shared config is defined at https://github.com/biltrewards/renovate-config/blob/main/default.json.

Link to Devin session: https://bilt.devinenterprise.com/sessions/798e4cd037d447cf8142953a27690319
Requested by: @tdabasinskas