### PR TITLE
chore: enable Renovate fork processing via root renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,0 @@
-{
-    "extends": [
-        "github>biltrewards/renovate-config"
-    ]
-}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "forkProcessing": "enabled",
+  "extends": ["github>biltrewards/renovate-config"]
+}


### PR DESCRIPTION
Forked repos are skipped by Mend Renovate because the fork gate (`validateIncludeForks`) makes a single GitHub API call to **root `renovate.json`** to decide whether to process the repo — it does not clone forks, so config in `.github/` is invisible to that check and the run aborts with "Repository is a fork and not manually configured - skipping".

This PR:
- Adds a root `renovate.json` with `forkProcessing: "enabled"` so the fork gate lets the repo through, plus `extends` to pull in the shared `github>biltrewards/renovate-config` preset.
- Removes `.github/renovate.json`: when a root `renovate.json` exists Renovate uses it and ignores the `.github/` one, so keeping both would just be a confusing redundant file.

Refs the org-wide fork-processing work in biltrewards/renovate-config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)